### PR TITLE
Add failing test for at-rules not being linted

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -99,3 +99,20 @@ testRule(selectorBemPattern.rule, {
     },
   ],
 });
+
+testRule(selectorBemPattern.rule, {
+  ruleName: selectorBemPattern.ruleName,
+  config: {
+    componentName: '^[a-z]+$',
+    componentSelectors: '^\\.{componentName}$',
+  },
+  skipBasicChecks: true,
+
+  accept: [
+    { code: '/** @define foo */ .foo { @include(example) }' },
+  ],
+
+  reject: [
+    { code: '/** @define foo */ .bar { @include(example) }' },
+  ],
+});


### PR DESCRIPTION
```scss
/** @define foo */

.foo {
  // This is fine
}

.bar {
  // This is not fine, and gets linted correctly
}

.baz {
  @include(example);
  // This is not fine, but does not get linted correctly
}
```

Including a mixin breaks linting for the entire file