### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '12', '14', '16' ]
+    name: Run tests on Node ${{ matrix.node }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: npm install
+      - name: Run tests
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: node_js
-node_js:
-  - "6"
-  - "stable"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stylelint-selector-bem-pattern
 
-[![Build Status](https://travis-ci.org/simonsmith/stylelint-selector-bem-pattern.svg?branch=master)](https://travis-ci.org/simonsmith/stylelint-selector-bem-pattern)
+[![Build Status](https://github.com/simonsmith/stylelint-selector-bem-pattern/actions/workflows/ci.yml/badge.svg)](https://github.com/simonsmith/stylelint-selector-bem-pattern/actions/workflows/ci.yml)
 
 A [stylelint](https://github.com/stylelint/stylelint) plugin that incorporates [postcss-bem-linter](https://github.com/postcss/postcss-bem-linter).
 


### PR DESCRIPTION
### Current Problem

Travis build is failing on Node 6 but passing on Node latest.

https://travis-ci.org/github/simonsmith/stylelint-selector-bem-pattern/jobs/770353884

Don't think we need to support as low as Node 6.

### Solution

Replace Travis with GitHub Actions, run on Node versions 12, 14 and 16.