### PR TITLE
deps: move `eslint-plugin-jest` to `devDependency`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "url": "https://github.com/simonsmith/stylelint-selector-bem-pattern/issues"
   },
   "homepage": "https://github.com/simonsmith/stylelint-selector-bem-pattern#readme",
-  "dependencies": {
-    "eslint-plugin-jest": "^27.2.2",
+  "dependencies": {   
     "lodash": ">=4.17.21",
     "postcss": "^8.4.24",
     "postcss-bem-linter": "^4.0.1"
   },
   "devDependencies": {
     "eslint": "^7.31.0",
+    "eslint-plugin-jest": "^27.2.2",
     "jest": "^29.5.0",
     "jest-preset-stylelint": "^7.0.0",
     "stylelint": "^16.2.1"


### PR DESCRIPTION
Hi!

fixed this  https://github.com/simonsmith/stylelint-selector-bem-pattern/issues/72