### PR TITLE
Update index.js – Removed deprecated 'line' from utils.report

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,8 @@ export default stylelint.createPlugin(ruleName, function(options) {
         ruleName: ruleName,
         result: result,
         node: warning.node || root,
+        index: warning.node.source.start.offset,
+        endIndex: warning.node.source.end.offset,
         column: warning.column,
         message: warning.text + ' (' + ruleName + ')',
       });

--- a/index.js
+++ b/index.js
@@ -57,13 +57,13 @@ export default stylelint.createPlugin(ruleName, function(options) {
     var bemLinterWarnings = bemLinterResult.warnings();
 
     bemLinterWarnings.forEach(function(warning) {
+      var node = warning.node || root;
       stylelint.utils.report({
         ruleName: ruleName,
         result: result,
-        node: warning.node || root,
-        index: warning.node.source.start.offset,
-        endIndex: warning.node.source.end.offset,
-        column: warning.column,
+        node: node,
+        index: 0,
+        endIndex: node.selector !== undefined ? node.selector.length : 0,
         message: warning.text + ' (' + ruleName + ')',
       });
     });

--- a/index.js
+++ b/index.js
@@ -61,7 +61,6 @@ export default stylelint.createPlugin(ruleName, function(options) {
         ruleName: ruleName,
         result: result,
         node: warning.node || root,
-        line: warning.line,
         column: warning.column,
         message: warning.text + ' (' + ruleName + ')',
       });


### PR DESCRIPTION
Removing deprecated 'line' from utils.report. 

_"Stylelint: (notice:6847)[stylelint:D07]DeprecationWarning: Providing the line argument in the util.report() function is deprecated ("plugin/selector-bem-pattern")."_